### PR TITLE
Issue/119

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -74,6 +74,11 @@ function vendd_setup() {
 		'default-color' => 'f1f1f1',
 		'default-image' => /* get_template_directory_uri() . '/inc/images/your_image.png' */ '',
 	) ) );
+
+	/*
+	 * Add theme support for title tag
+	 */
+	add_theme_support( 'title-tag' );
 }
 endif; // vendd_setup
 add_action( 'after_setup_theme', 'vendd_setup' );

--- a/functions.php
+++ b/functions.php
@@ -83,6 +83,18 @@ function vendd_setup() {
 endif; // vendd_setup
 add_action( 'after_setup_theme', 'vendd_setup' );
 
+/**
+ * Title tag back compat
+ */
+if ( ! function_exists( '_wp_render_title_tag' ) ) {
+    function vendd_render_title() {
+        ?>
+        <title><?php wp_title( '|', true, 'right' ); ?></title>
+        <?php
+    }
+    add_action( 'wp_head', 'vendd_render_title' );
+}
+
 
 /**
  * Add search to main menu

--- a/header.php
+++ b/header.php
@@ -11,7 +11,6 @@
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title><?php wp_title( '|', true, 'right' ); ?></title>
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 <?php wp_head(); ?>


### PR DESCRIPTION
Add theme support for `title-tag`, with back-compatibility for pre WP 4.1 installs.

Fixes https://github.com/easydigitaldownloads/vendd/issues/119#issuecomment-155269406