### PR TITLE
remove white background on checkout CC field #258

### DIFF
--- a/style.css
+++ b/style.css
@@ -2399,10 +2399,6 @@ input[type="submit"].edd-submit {
 #edd_checkout_wrap #edd_checkout_form_wrap #edd_purchase_submit {
 	background: none;
 }
-#edd_checkout_wrap #edd_cc_fields input:not([type="submit"]),
-#edd_checkout_wrap #edd_cc_fields select {
-	background: #fff;
-}
 #edd_show_terms {
 	font-size: .87em;
 	margin-bottom: 10px;


### PR DESCRIPTION
See #258 

Proposed changes:

1. Remove the white background for checkout form CC fields IAW the following EDD update: https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6953